### PR TITLE
unicode/utf16: RuneLen

### DIFF
--- a/unicode/utf16/utf16.go
+++ b/unicode/utf16/utf16.go
@@ -19,8 +19,8 @@ func DecodeRune(r1, r2 rune) rune
 // EncodeRuneはU+FFFD、U+FFFDを返します。
 func EncodeRune(r rune) (r1, r2 rune)
 
-// RuneLen returns the number of 16-bit words in the UTF-16 encoding of the rune.
-// It returns -1 if the rune is not a valid value to encode in UTF-16.
+// RuneLenは、ルーンのUTF-16エンコーディングに含まれる16ビットワードの数を返します。
+// ルーンがUTF-16でエンコードするための有効な値でない場合、-1を返します。
 func RuneLen(r rune) int
 
 // EncodeはUnicodeコードポイントの列sのUTF-16エンコーディングを返します。


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **ドキュメント**
	- `utf16.go`内のコメントと関数名に日本語の文字を使用して、明確性を向上させました。機能性には影響しません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->