### PR TITLE
time: NewTicker, close #259

### DIFF
--- a/time/tick.go
+++ b/time/tick.go
@@ -10,21 +10,18 @@ type Ticker struct {
 	initTicker bool
 }
 
-// NewTicker returns a new Ticker containing a channel that will send
-// the current time on the channel after each tick. The period of the
-// ticks is specified by the duration argument. The ticker will adjust
-// the time interval or drop ticks to make up for slow receivers.
-// The duration d must be greater than zero; if not, NewTicker will
-// panic.
+// NewTickerは、各ティック後にチャネル上の現在の時間を送信するチャネルを含む新しいTickerを返します。
+// ティックの周期は、duration引数で指定されます。Tickerは、受信速度が遅い場合に時間間隔を調整したり、
+// ティックをドロップしたりします。duration dはゼロより大きくなければならず、そうでない場合、
+// NewTickerはパニックを起こします。
 //
-// Before Go 1.23, the garbage collector did not recover
-// tickers that had not yet expired or been stopped, so code often
-// immediately deferred t.Stop after calling NewTicker, to make
-// the ticker recoverable when it was no longer needed.
-// As of Go 1.23, the garbage collector can recover unreferenced
-// tickers, even if they haven't been stopped.
-// The Stop method is no longer necessary to help the garbage collector.
-// (Code may of course still want to call Stop to stop the ticker for other reasons.)
+// Go 1.23より前では、ガベージコレクタはまだ期限切れになっていないか停止していない
+// tickerを回収しなかったため、コードはしばしばNewTickerを呼び出した直後にt.Stopを即時に遅延させ、
+// tickerが不要になったときに回収可能にしました。
+// Go 1.23以降では、ガベージコレクタは参照されていないtickerを回収できます、
+// たとえそれらが停止していなくても。
+// Stopメソッドはもはやガベージコレクタを助けるためには必要ありません。
+// （もちろん、コードは他の理由でtickerを停止させるためにStopを呼び出すことを望むかもしれません。）
 func NewTicker(d Duration) *Ticker
 
 // Stopはティッカーを停止します。Stop後は、もうティックが送信されません。


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **ドキュメント**
	- `NewTicker`関数の動作に関する説明を更新し、Go 1.23以降のバージョンでのtickerの回収についてのコメントを明確にしました。ガベージコレクションのために`Stop`を呼び出す必要性についても言及しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->